### PR TITLE
Hotfix/format date

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "php": "^7.4|^8.0",
+        "php": "^8.2",
         "nesbot/carbon": "^2.0",
-        "laravel/framework": "^8.75|^9.0",
+        "laravel/framework": "^10.0",
         "league/commonmark": "^2.0",
         "romanzipp/laravel-seo": "^2.1.3",
         "spatie/yaml-front-matter": "^2.0",

--- a/src/Commands/BuildBlog.php
+++ b/src/Commands/BuildBlog.php
@@ -146,10 +146,7 @@ class BuildBlog extends Command
             $article = YamlFrontMatter::parse(file_get_contents($file->getRealPath()));
 
             // Check if the file is ready for release.
-            if (Carbon::createFromFormat(
-                config('blog.date_format', 'Y-m-d H:i:s'),
-                $article->matter()['modified']
-            )->isPast()) {
+            if ((new Carbon($article->matter()['modified']))->isPast()) {
                 $releaseFiles[] = $file;
             }
         }

--- a/src/Commands/BuildBlog.php
+++ b/src/Commands/BuildBlog.php
@@ -271,10 +271,7 @@ class BuildBlog extends Command
         // Check if this article should be converted or is still unpublished.
         return
             isset($data['published']) &&
-            Carbon::createFromFormat(
-                config('blog.date_format', 'Y-m-d H:i:s'),
-                $data['published']
-            )->isPast();
+            (new Carbon($data['published']))->isPast();
     }
 
     /**
@@ -528,13 +525,9 @@ class BuildBlog extends Command
 
         // Published
         if (isset($frontmatter['published'])) {
+            $date = (new Carbon($frontmatter['published']));
             seo()->addMany([
-                Article::make()->property('published_time')->content(
-                    Carbon::createFromFormat(
-                        config('blog.date_format', 'Y-m-d H:i:s'),
-                        $frontmatter['published']
-                    )->toAtomString()
-                ),
+                Article::make()->property('published_time')->content($date->toAtomString()),
             ]);
         }
 
@@ -553,10 +546,11 @@ class BuildBlog extends Command
         // Modified
         if (isset($frontmatter['modified'])) {
             // Prep the date string
-            $date = Carbon::createFromFormat(
+            /*$date = Carbon::createFromFormat(
                 config('blog.date_format', 'Y-m-d H:i:s'),
                 $frontmatter['modified']
-            )->toAtomString();
+            )->toAtomString();*/
+            $date = (new Carbon($frontmatter['modified']))->toAtomString();
 
             // Add in
             seo()->addMany([

--- a/src/Commands/BuildBlog.php
+++ b/src/Commands/BuildBlog.php
@@ -286,7 +286,6 @@ class BuildBlog extends Command
 
         // Prepares the data
         $data = $this->prepareData($file->getRealPath());
-        dump($data);
 
         // Define the target directory and create it (optionally).
         $targetURL = preg_replace('/\.md$/', '/', $file->getRelativePathname());
@@ -330,14 +329,23 @@ class BuildBlog extends Command
             ]
         );
 
-        if (isset($data['published'])) {
-            dump($data['published']);
-            $date = (new Carbon($data['published']));
-            $data['published'] = $date->format(config('blog.date_format', 'Y-m-d H:i:s'));
-            dump($data['published']);
+        return $this->formatDateFields($data);
+    }
+
+    /**
+     * @param array $fields
+     * @return array
+     */
+    private function formatDateFields(array $fields): array
+    {
+        if (isset($fields['published'])) {
+            dump($fields['published']);
+            $date = (new Carbon($fields['published']));
+            $fields['published_formatted'] = $date->format(config('blog.date_format', 'Y-m-d H:i:s'));
+            dump($fields['published_formatted']);
         }
 
-        return $data;
+        return $fields;
     }
 
     /**
@@ -556,10 +564,6 @@ class BuildBlog extends Command
         // Modified
         if (isset($frontmatter['modified'])) {
             // Prep the date string
-            /*$date = Carbon::createFromFormat(
-                config('blog.date_format', 'Y-m-d H:i:s'),
-                $frontmatter['modified']
-            )->toAtomString();*/
             $date = (new Carbon($frontmatter['modified']))->toAtomString();
 
             // Add in

--- a/src/Commands/BuildBlog.php
+++ b/src/Commands/BuildBlog.php
@@ -330,6 +330,10 @@ class BuildBlog extends Command
     }
 
     /**
+     * Format the date fields of the blog post using the date format specified
+     * in the config file. The original field will be kept for backwards
+     * compatibility.
+     *
      * @param array $fields
      * @return array
      */

--- a/src/Commands/BuildBlog.php
+++ b/src/Commands/BuildBlog.php
@@ -338,11 +338,13 @@ class BuildBlog extends Command
      */
     private function formatDateFields(array $fields): array
     {
-        if (isset($fields['published'])) {
-            dump($fields['published']);
-            $date = (new Carbon($fields['published']));
-            $fields['published_formatted'] = $date->format(config('blog.date_format', 'Y-m-d H:i:s'));
-            dump($fields['published_formatted']);
+        $dates = ['published', 'modified'];
+
+        foreach ($dates as $dateField) {
+            if (isset($fields[$dateField])) {
+                $date = (new Carbon($fields[$dateField]));
+                $fields[$dateField . '_formatted'] = $date->format(config('blog.date_format', 'Y-m-d H:i:s'));
+            }
         }
 
         return $fields;

--- a/src/Commands/BuildBlog.php
+++ b/src/Commands/BuildBlog.php
@@ -286,6 +286,7 @@ class BuildBlog extends Command
 
         // Prepares the data
         $data = $this->prepareData($file->getRealPath());
+        dump($data);
 
         // Define the target directory and create it (optionally).
         $targetURL = preg_replace('/\.md$/', '/', $file->getRelativePathname());
@@ -321,13 +322,22 @@ class BuildBlog extends Command
         $article = YamlFrontMatter::parse(file_get_contents($filename));
 
         // Prepare the information to hand to the view - the frontmatter and headers+content.
-        return array_merge(
+        $data = array_merge(
             array_merge(config('blog.defaults', []), $article->matter()),
             [
                 'header' => $this->prepareLaravelSEOHeaders($article->matter()),
                 'content' => $this->converter->convertToHtml($article->body()),
             ]
         );
+
+        if (isset($data['published'])) {
+            dump($data['published']);
+            $date = (new Carbon($data['published']));
+            $data['published'] = $date->format(config('blog.date_format', 'Y-m-d H:i:s'));
+            dump($data['published']);
+        }
+
+        return $data;
     }
 
     /**


### PR DESCRIPTION
When I was modifying the date format to be output on an article or a list, an error would occur when running the build:blog command. After looking into it further, it appears that the date format config variable is being used incorrectly and is being used for all date logic.

For example, I have modified the check to know if a file is ready for release to create a carbon object using the modified field. Then I am checking if the date has passed using the carbon object. The format of the date is not relevant in this check.

A new field for each date field has been created to use in the template that is actually the formatted date. This works for both articles and lists.